### PR TITLE
feat: Navigate to progress screen and limit search results

### DIFF
--- a/backend/agents/research_workflow.py
+++ b/backend/agents/research_workflow.py
@@ -108,7 +108,7 @@ def research_node(state: KnowledgeNexusState, chroma_service: ChromaService) -> 
         try:
             print(f"Attempting Google Custom Search for query: '{topic}'")
             service = build("customsearch", "v1", developerKey=GOOGLE_API_KEY)
-            result = service.cse().list(q=topic, cx=GOOGLE_CSE_ID, num=5).execute()
+            result = service.cse().list(q=topic, cx=GOOGLE_CSE_ID, num=20).execute()
 
             google_search_items = result.get("items", [])
             print(f"Google Search returned {len(google_search_items)} items.")

--- a/frontend/src/components/Home.js
+++ b/frontend/src/components/Home.js
@@ -43,18 +43,20 @@ function Home() {
         </p>
       </header>
 
-      <div className="research-input-section">
-        <input
-          type="text"
-          value={topic}
-          onChange={handleTopicChange}
-          placeholder="E.g., The impact of AI on climate change"
-          className="research-topic-input"
-        />
-        <button onClick={handleStartResearch} className="start-research-button">
-          Start Researching
-        </button>
-      </div>
+      {!(researchStatus && researchStatus.task_id) && (
+        <div className="research-input-section">
+          <input
+            type="text"
+            value={topic}
+            onChange={handleTopicChange}
+            placeholder="E.g., The impact of AI on climate change"
+            className="research-topic-input"
+          />
+          <button onClick={handleStartResearch} className="start-research-button">
+            Start Researching
+          </button>
+        </div>
+      )}
 
       {error && (
         <div className="error-message">


### PR DESCRIPTION
This commit implements two main changes:

1.  Frontend: After you submit a research topic, the application now transitions from the home screen to the research progress screen. The search input fields are hidden, and the `ResearchProgress` component is displayed, showing the status of the ongoing research.

2.  Backend: The Google Custom Search API integration in the `research_node` has been updated to fetch 20 results per query, increased from the previous limit of 5. This provides a more comprehensive set of initial data for the research workflow.