### PR TITLE
Here's how I've clarified the Google Custom Search API usage for web-…

### DIFF
--- a/backend/agents/research_workflow.py
+++ b/backend/agents/research_workflow.py
@@ -108,6 +108,10 @@ def research_node(state: KnowledgeNexusState, chroma_service: ChromaService) -> 
         try:
             print(f"Attempting Google Custom Search for query: '{topic}'")
             service = build("customsearch", "v1", developerKey=GOOGLE_API_KEY)
+            # By default, when 'searchType' is not specified, the API returns web page results.
+            # Note: The Programmable Search Engine (PSE) configuration (via GOOGLE_CSE_ID)
+            # in the Google Cloud Console also influences search scope. Ensure it's configured
+            # to 'Search the entire web' or for web-only sources for best results.
             result = service.cse().list(q=topic, cx=GOOGLE_CSE_ID, num=20).execute()
 
             google_search_items = result.get("items", [])


### PR DESCRIPTION
…only results in your code:

I reviewed the code and confirmed that the Google Custom Search API is being used to fetch web-only search results. This happens because of the API's default behavior – when the `searchType` parameter isn't specified in the `cse().list()` method, it automatically limits the results to webpages.

I've added comments to `backend/agents/research_workflow.py` to:
1.  Explain that the API's default behavior (without `searchType`) is to return web-only results.
2.  Note that the Programmable Search Engine (PSE) configuration in your Google Cloud Console also influences the search scope. You'll want to make sure it's set up appropriately (for example, "Search the entire web") if you need a comprehensive web search.

No changes to the actual code were needed because the current setup already correctly fetches web-only results by default.