### PR TITLE
feat: Implement 'View Results' functionality

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,12 +1,19 @@
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Home from './components/Home';
+import ResultsView from './components/ResultsView'; // Ensure this path is correct
 import './App.css';
 
 function App() {
   return (
-    <div className="App">
-      <Home />
-    </div>
+    <Router>
+      <div className="App">
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/results/:taskId" element={<ResultsView />} />
+        </Routes>
+      </div>
+    </Router>
   );
 }
-
 export default App;

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -68,6 +68,33 @@ export const startResearchTopic = async (topic) => {
 };
 
 /**
+ * Fetches the results of a specific research task.
+ * @param {string} taskId - The ID of the task.
+ * @returns {Promise<Object>} A promise that resolves to the task results data.
+ * @throws {Error} If the request fails.
+ */
+export const getTaskResults = async (taskId) => {
+  if (!taskId) {
+    throw new Error('Task ID cannot be empty for getTaskResults.');
+  }
+  try {
+    const response = await axios.get(`${API_BASE_URL}/results/${taskId}`);
+    console.log(`API call /results/${taskId} successful, response data:`, response.data);
+    return response.data; // Expected: { document_content: "...", ... }
+  } catch (error) {
+    console.error(`Error fetching results for task ${taskId}:`, error.message);
+    if (error.response) {
+      console.error('Error response data (getTaskResults):', error.response.data);
+      throw new Error(error.response.data.detail || `Failed to fetch results (status ${error.response.status})`);
+    } else if (error.request) {
+      throw new Error('No response from server while fetching task results.');
+    } else {
+      throw new Error(`An unexpected error occurred while fetching task results: ${error.message}`);
+    }
+  }
+};
+
+/**
  * (Placeholder) Initiates document generation for a task with specified options.
  * @param {string} taskId - The ID of the task.
  * @param {Object} exportOptions - Options for document generation.

--- a/frontend/src/components/ResearchProgress.js
+++ b/frontend/src/components/ResearchProgress.js
@@ -1,10 +1,12 @@
 import React, { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { getTaskStatus, submitVerification } from '../api';
 import './ResearchProgress.css';
 
 const DEFAULT_POLL_INTERVAL = 5000; // 5 seconds
 
 function ResearchProgress({ taskId }) {
+  const navigate = useNavigate();
   const [statusDetails, setStatusDetails] = useState(null);
   const [error, setError] = useState(null);
   const [isLoading, setIsLoading] = useState(false); // For individual actions like submitting verification
@@ -185,7 +187,13 @@ function ResearchProgress({ taskId }) {
         <div className="completion-message-block card">
           <h3>Research Complete</h3>
           <p>{message || "The research task has been successfully completed."}</p>
-          <button disabled className="placeholder-button">View Results (Not Implemented Yet)</button>
+          <button
+            onClick={() => navigate(`/results/${statusDetails.task_id}`)}
+            disabled={isLoading || status !== 'completed'}
+            className="view-results-button"
+          >
+            View Results
+          </button>
         </div>
       )}
       {/* Show regular message only if not completed, to avoid redundancy with the block above */}

--- a/frontend/src/components/ResultsView.css
+++ b/frontend/src/components/ResultsView.css
@@ -1,0 +1,42 @@
+.results-view-container {
+  padding: 20px;
+  max-width: 800px;
+  margin: 20px auto;
+  background-color: #f9f9f9;
+  border: 1px solid #eee;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.results-view-container h1 {
+  text-align: center;
+  color: #333;
+  margin-bottom: 20px;
+}
+
+.results-content {
+  background-color: #fff;
+  padding: 20px;
+  border-radius: 4px;
+  border: 1px solid #ddd;
+  line-height: 1.6;
+}
+
+.results-content h1, .results-content h2, .results-content h3 {
+  margin-top: 20px;
+  margin-bottom: 10px;
+}
+
+.results-content p {
+  margin-bottom: 10px;
+}
+
+.results-content ul, .results-content ol {
+  margin-left: 20px;
+  margin-bottom: 10px;
+}
+
+.error-message {
+  color: red;
+  text-align: center;
+}

--- a/frontend/src/components/ResultsView.js
+++ b/frontend/src/components/ResultsView.js
@@ -1,0 +1,46 @@
+import React, { useState, useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { getTaskResults } from '../api';
+import './ResultsView.css';
+
+const ResultsView = () => {
+  const { taskId } = useParams();
+  const [results, setResults] = useState(null);
+  const [error, setError] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchResults = async () => {
+      if (!taskId) return;
+      setIsLoading(true);
+      setError(null);
+      try {
+        const data = await getTaskResults(taskId);
+        setResults(data);
+      } catch (err) {
+        setError(err.message || 'Failed to fetch results');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchResults();
+  }, [taskId]);
+
+  return (
+    <div className="results-view-container">
+      {isLoading && <p>Loading results for task {taskId}...</p>}
+      {error && <p className="error-message">Error fetching results: {error}</p>}
+      {results && (
+        <>
+          <h1>Research Results</h1>
+          {/* Optional: Display topic if available */}
+          {/* <p><strong>Topic:</strong> {results.topic || taskId}</p> */}
+          <article className="results-content" dangerouslySetInnerHTML={{ __html: results.document_content }} />
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ResultsView;


### PR DESCRIPTION
This commit introduces the full flow for viewing completed research task results.

Backend:
- No changes were made as the existing `/results/{task_id}` endpoint was deemed sufficient for providing the document content.

Frontend:
- Added `getTaskResults(taskId)` function in `api.js` to fetch results from the backend.
- Created `ResultsView.js` component and `ResultsView.css` to display the fetched research document content.
- Installed `react-router-dom` and configured routes in `App.js` to include a new page for `/results/:taskId` that renders `ResultsView`.
- Updated `ResearchProgress.js`:
    - The "View Results" button is now enabled when a task is completed.
    - Clicking the button navigates you to the corresponding results page.