### PR TITLE
Fix: Resolve Unterminated JSX contents error in App.js

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -25,6 +25,7 @@ function App() {
           <Route path="/community" element={<div>Community Page Placeholder</div>} />
         </Routes>
       </div>
+    </div>
     </Router>
   );
 }


### PR DESCRIPTION
The build was failing due to an unterminated JSX error in `frontend/src/App.js`. This was caused by a missing closing `</div>` tag for the main application container.

This commit adds the necessary closing `</div>` tag, allowing the application to build and run correctly.