### PR TITLE
feat: Implement markdown rendering for research content

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2",
+    "react-markdown": "^9.0.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/frontend/src/components/ResearchProgress.js
+++ b/frontend/src/components/ResearchProgress.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
+import ReactMarkdown from 'react-markdown';
 import { getTaskStatus, submitVerification } from '../api';
 import './ResearchProgress.css';
 
@@ -275,7 +276,8 @@ function ResearchProgress({ taskId }) {
               <h3 className="section-title">Human Verification Needed</h3>
               <div className="verification-item"> {/* Removed card class, parent is a card */}
                 <h4>Item to Verify (ID: {verification_request.data_id})</h4>
-                <p><strong>Content Preview:</strong> {verification_request.data_to_verify.content_preview}</p>
+                  <p><strong>Content Preview:</strong></p>
+                  <ReactMarkdown>{verification_request.data_to_verify.content_preview}</ReactMarkdown>
                 {verification_request.data_to_verify.url && (
                   <p><strong>URL:</strong> <a href={verification_request.data_to_verify.url} target="_blank" rel="noopener noreferrer">{verification_request.data_to_verify.url}</a></p>
                 )}
@@ -288,7 +290,8 @@ function ResearchProgress({ taskId }) {
                     {verification_request.conflicting_sources.map(source => (
                       <li key={source.id}>
                         <p><strong>ID:</strong> {source.id}</p>
-                        <p><strong>Preview:</strong> {source.content_preview}</p>
+                        <p><strong>Preview:</strong></p>
+                        <ReactMarkdown>{source.content_preview}</ReactMarkdown>
                         {source.url && <p><strong>URL:</strong> <a href={source.url} target="_blank" rel="noopener noreferrer">{source.url}</a></p>}
                       </li>
                     ))}

--- a/frontend/src/components/ResultsView.js
+++ b/frontend/src/components/ResultsView.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
+import ReactMarkdown from 'react-markdown';
 import { getTaskResults } from '../api';
 import './ResultsView.css';
 
@@ -36,7 +37,7 @@ const ResultsView = () => {
           <h1>Research Results</h1>
           {/* Optional: Display topic if available */}
           {/* <p><strong>Topic:</strong> {results.topic || taskId}</p> */}
-          <article className="results-content" dangerouslySetInnerHTML={{ __html: results.document_content }} />
+          <ReactMarkdown className="results-content">{results.document_content}</ReactMarkdown>
         </>
       )}
     </div>


### PR DESCRIPTION
This commit introduces markdown rendering capabilities to the frontend to correctly display formatted research results and content previews.

Key changes:
- Added `react-markdown` library to handle markdown-to-HTML conversion.
- Modified `ResultsView.js` to use `ReactMarkdown` for displaying `results.document_content`, ensuring that research findings are rendered with proper markdown formatting.
- Updated `ResearchProgress.js` to use `ReactMarkdown` for `verification_request.data_to_verify.content_preview` and `source.content_preview` in the human verification and conflicting sources sections, respectively.

These changes address the issue of markdown content being displayed as plain text, improving the readability and presentation of information across relevant screens.